### PR TITLE
feat: interactive env var prompt for sekret add

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -16,9 +16,9 @@ var addCmd = &cobra.Command{
 	Long: `Register a new API key in the OS keychain.
 
 For built-in keys (openai, anthropic, gemini, github, groq),
-the environment variable name is automatically mapped.
+the environment variable name is suggested as a default.
 
-For custom keys, use the --env flag:
+Use the --env flag to skip the env var prompt:
   sekret add my-service --env MY_SERVICE_KEY`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAdd,
@@ -32,6 +32,34 @@ func init() {
 var validNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 var validEnvVarPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// promptEnvVar prompts the user for an env var name.
+// If a registry entry exists, the entry's env var is suggested as the default.
+func promptEnvVar(entry *registry.Entry) (string, error) {
+	if entry != nil {
+		// Known key: suggest default, allow customization
+		input, err := readInput(fmt.Sprintf("  Env variable (press Enter for %q): ", entry.EnvVar))
+		if err != nil {
+			return "", err
+		}
+		input = strings.TrimSpace(input)
+		if input == "" {
+			return entry.EnvVar, nil
+		}
+		return input, nil
+	}
+
+	// Unknown key: require input
+	input, err := readInput("  Env variable: ")
+	if err != nil {
+		return "", err
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("environment variable name is required")
+	}
+	return input, nil
+}
+
 func runAdd(c *cobra.Command, args []string) error {
 	name := strings.ToLower(args[0])
 
@@ -39,21 +67,7 @@ func runAdd(c *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid key name %q: use only lowercase letters, numbers, hyphens, and underscores", name)
 	}
 
-	// Determine env var name
-	envVar, _ := c.Flags().GetString("env")
-	entry := registry.Lookup(name)
-	if envVar == "" {
-		if entry == nil {
-			return fmt.Errorf("unknown key %q: use --env to specify the environment variable name", name)
-		}
-		envVar = entry.EnvVar
-	}
-
-	if !validEnvVarPattern.MatchString(envVar) {
-		return fmt.Errorf("invalid environment variable name %q: use only letters, numbers, and underscores (cannot start with a number)", envVar)
-	}
-
-	// Check if already registered
+	// Check if name already registered (before any prompts)
 	cfg, err := config.Load()
 	if err != nil {
 		return err
@@ -61,6 +75,23 @@ func runAdd(c *cobra.Command, args []string) error {
 	if cfg.FindKey(name) != nil {
 		return fmt.Errorf("key %q is already registered (use 'sekret set %s' to update)", name, name)
 	}
+
+	// Determine env var name
+	envVar, _ := c.Flags().GetString("env")
+	entry := registry.Lookup(name)
+	if envVar == "" {
+		// No --env flag: prompt interactively
+		envVar, err = promptEnvVar(entry)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !validEnvVarPattern.MatchString(envVar) {
+		return fmt.Errorf("invalid environment variable name %q: use only letters, numbers, and underscores (cannot start with a number)", envVar)
+	}
+
+	// Check if env var already used
 	if existing := cfg.FindKeyByEnvVar(envVar); existing != nil {
 		return fmt.Errorf("environment variable %q is already used by key %q", envVar, existing.Name)
 	}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -23,6 +23,9 @@ func setup(t *testing.T) {
 	cmd.SetReadPassword(func(_ string) (string, error) {
 		return "", fmt.Errorf("readPassword not configured for this test")
 	})
+	cmd.SetReadInput(func(_ string) (string, error) {
+		return "", fmt.Errorf("readInput not configured for this test")
+	})
 	cmd.SetReadConfirm(func(_ string) (bool, error) {
 		return false, fmt.Errorf("readConfirm not configured for this test")
 	})
@@ -30,6 +33,7 @@ func setup(t *testing.T) {
 		config.SetPath("")
 		cmd.SetStore(keychain.NewOSStore())
 		cmd.SetReadPassword(nil)
+		cmd.SetReadInput(nil)
 		cmd.SetReadConfirm(nil)
 		testStore = nil
 	})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 
@@ -33,6 +34,26 @@ var readPassword = func(prompt string) (string, error) {
 // SetReadPassword overrides the password reader (for testing).
 func SetReadPassword(fn func(string) (string, error)) {
 	readPassword = fn
+}
+
+// readInput reads a line of visible text from the user.
+// Returns empty string if user presses Enter without typing.
+// Override with SetReadInput() for testing.
+var readInput = func(prompt string) (string, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", fmt.Errorf("failed to read input: %w", err)
+		}
+		return "", fmt.Errorf("failed to read input: EOF")
+	}
+	return scanner.Text(), nil
+}
+
+// SetReadInput overrides the input reader (for testing).
+func SetReadInput(fn func(string) (string, error)) {
+	readInput = fn
 }
 
 // readConfirm reads a y/N confirmation from the user.


### PR DESCRIPTION
## Summary

- `sekret add` now prompts for env var name interactively when `--env` flag is not provided
- Built-in registry keys suggest a default (e.g. `OPENAI_API_KEY`), customizable by the user
- Unknown keys require the user to input an env var name

## Example

Built-in key (accept default):
```
$ sekret add openai
  Env variable (press Enter for "OPENAI_API_KEY"): 
  API Key: ••••••••••••••••
  Saved to OS keychain (OPENAI_API_KEY)
```

Built-in key (custom env var):
```
$ sekret add openai
  Env variable (press Enter for "OPENAI_API_KEY"): MY_OPENAI_KEY
  API Key: ••••••••••••••••
  Saved to OS keychain (MY_OPENAI_KEY)
```

Unknown key (interactive):
```
$ sekret add my-service
  Env variable: MY_SERVICE_KEY
  API Key: ••••••••••••••••
  Saved to OS keychain (MY_SERVICE_KEY)
```

`--env` flag (skip prompt):
```
$ sekret add my-service --env MY_SERVICE_KEY
  API Key: ••••••••••••••••
  Saved to OS keychain (MY_SERVICE_KEY)
```

## Changes

- Add `readInput()` / `SetReadInput()` to `cmd/root.go` for non-secret text prompts
- Add `promptEnvVar()` to `cmd/add.go` for interactive env var selection
- Move name duplicate check before interactive prompts to avoid unnecessary input
- Update help text to reflect new behavior
- Add new tests: `TestAdd_BuiltinKeyCustomEnv`, `TestAdd_UnknownKeyInteractive`, `TestAdd_UnknownKeyEmptyEnvVar`
- Update existing tests to configure `readInput` mock

## Related Issues

None (improvement discovered during v0.2 spec design)

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Build succeeds (`make build`)