### PR TITLE
chore: add GoReleaser config and release workflow for Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+version: 2
+
+builds:
+  - binary: sekret
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^test:"
+
+brews:
+  - repository:
+      owner: eazyhozy
+      name: homebrew-sekret
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/eazyhozy/sekret"
+    description: "Secure your API keys in OS keychain, load them as env vars"
+    license: "MIT"
+    install: |
+      bin.install "sekret"
+    test: |
+      system "#{bin}/sekret", "--help"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ sekret stores your keys in the OS keychain (macOS Keychain, GNOME Keyring) and l
 
 ## Installation
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install eazyhozy/sekret/sekret
+```
+
+### Go
+
 ```bash
 go install github.com/eazyhozy/sekret@latest
 ```


### PR DESCRIPTION
## Summary

Set up GoReleaser and GitHub Actions release workflow for Homebrew tap distribution.

## Changes

- **`.goreleaser.yml`** — Cross-compile for macOS (arm64/amd64) and Linux (amd64/arm64). Publish binaries to GitHub Release. Auto-update Homebrew formula in `eazyhozy/homebrew-sekret`.
- **`.github/workflows/release.yml`** — Trigger GoReleaser on `v*` tag push. Uses `GITHUB_TOKEN` for release and `HOMEBREW_TAP_TOKEN` for tap formula push.
- **`README.md`** — Add Homebrew install instructions (`brew install eazyhozy/sekret/sekret`).

## How to release

```bash
git tag v0.1.0
git push origin v0.1.0
```

This triggers the release workflow, which:
1. Cross-compiles binaries
2. Creates a GitHub Release with archives and checksums
3. Pushes the Homebrew formula to `eazyhozy/homebrew-sekret`

## Related Issues

Closes #10

## Checklist

- [x] Lint passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] Build succeeds (`make build`)
- [x] `HOMEBREW_TAP_TOKEN` secret configured in repo settings
- [x] `eazyhozy/homebrew-sekret` repository created (public)