### PR TITLE
feat: add --version flag with build-time version injection

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
+      - -s -w -X github.com/eazyhozy/sekret/cmd.version={{.Version}}
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 APP_NAME := sekret
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -s -w -X github.com/eazyhozy/sekret/cmd.version=$(VERSION)
 
 build:
-	go build -o $(APP_NAME) .
+	go build -ldflags "$(LDFLAGS)" -o $(APP_NAME) .
 
 test:
 	go test ./...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,9 @@ import (
 	"golang.org/x/term"
 )
 
+// version is set at build time via ldflags.
+var version = "dev"
+
 var validEnvVarPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // store is the keychain store used by all commands.
@@ -57,8 +60,9 @@ func SetReadConfirm(fn func(string) (bool, error)) {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "sekret",
-	Short: "Secure your API keys in OS keychain, load them as env vars",
+	Use:     "sekret",
+	Version: version,
+	Short:   "Secure your API keys in OS keychain, load them as env vars",
 	Long: `sekret stores your API keys in the OS keychain and injects them
 as environment variables. No more plaintext secrets in .zshrc.
 


### PR DESCRIPTION
## Summary

Add `sekret --version` / `sekret -v` support with build-time version injection via ldflags.

## Changes

- Add `version` variable in `cmd/root.go` with `"dev"` default, wire it to `rootCmd.Version`
- Update `.goreleaser.yml` ldflags to inject `{{.Version}}` from git tag at release time
- Update `Makefile` to inject version from `git describe --tags` for local builds

## Related Issues

None (minor enhancement)

## Checklist

- [x] Lint passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] Build succeeds (`make build`)