### PR TITLE
feat: add internal/scanner package for export statement parsing

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/eazyhozy/sekret/internal/config"
+	"github.com/eazyhozy/sekret/internal/scanner"
 	"github.com/spf13/cobra"
 )
 
@@ -19,31 +20,6 @@ var listCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(listCmd)
-}
-
-func maskKey(value string) string {
-	if len(value) <= 4 {
-		return "****"
-	}
-
-	// Find the prefix portion (up to the first meaningful character after known prefix patterns)
-	prefix := ""
-	prefixes := []string{"sk-proj-", "sk-ant-", "github_pat_", "sk-", "ghp_", "gsk_", "AIza"}
-	for _, p := range prefixes {
-		if len(value) >= len(p) && value[:len(p)] == p {
-			prefix = p
-			break
-		}
-	}
-
-	if prefix == "" && len(value) > 8 {
-		prefix = value[:4]
-	} else if prefix == "" {
-		prefix = value[:2]
-	}
-
-	suffix := value[len(value)-4:]
-	return prefix + "..." + suffix
 }
 
 func runList(_ *cobra.Command, _ []string) error {
@@ -64,7 +40,7 @@ func runList(_ *cobra.Command, _ []string) error {
 	for _, k := range cfg.Keys {
 		preview := "(unavailable)"
 		if val, err := store.Get(k.KeychainKey()); err == nil {
-			preview = maskKey(val)
+			preview = scanner.MaskValue(val)
 		}
 		added := humanize.Time(k.AddedAt)
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", k.EnvVar, preview, added)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/eazyhozy/sekret/internal/config"
 	"github.com/eazyhozy/sekret/internal/registry"
+	"github.com/eazyhozy/sekret/internal/scanner"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +38,7 @@ func runSet(_ *cobra.Command, args []string) error {
 
 	// Show current masked value
 	if current, err := store.Get(keychainKey); err == nil {
-		_, _ = fmt.Fprintf(rootCmd.ErrOrStderr(), "  Current: %s\n", maskKey(current))
+		_, _ = fmt.Fprintf(rootCmd.ErrOrStderr(), "  Current: %s\n", scanner.MaskValue(current))
 	}
 
 	// Read new key interactively

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,169 @@
+package scanner
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/eazyhozy/sekret/internal/registry"
+)
+
+// Finding represents a detected plaintext key in a file.
+type Finding struct {
+	FilePath string
+	Line     int
+	EnvVar   string
+	Value    string
+}
+
+// secretSuffixes are env var name suffixes that indicate a secret value.
+var secretSuffixes = []string{"_KEY", "_TOKEN", "_SECRET", "_CREDENTIALS"}
+
+// exportPattern matches `export KEY=VALUE` statements.
+var exportPattern = regexp.MustCompile(`^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(.+)$`)
+
+// knownPrefixes are API key prefixes used for mask display (longest first).
+var knownPrefixes = []string{
+	"sk-proj-", "sk-ant-", "github_pat_",
+	"sk-", "ghp_", "gsk_", "AIza",
+}
+
+// defaultTargetFiles are shell config filenames scanned by default.
+var defaultTargetFiles = []string{
+	".zshrc", ".zshenv", ".zprofile",
+	".bashrc", ".bash_profile",
+	".profile",
+}
+
+// DefaultTargets returns the default scan target paths in the home directory.
+func DefaultTargets() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	targets := make([]string, len(defaultTargetFiles))
+	for i, f := range defaultTargetFiles {
+		targets[i] = filepath.Join(home, f)
+	}
+	return targets
+}
+
+// ScanFile parses a single file for export statements containing potential secrets.
+func ScanFile(path string) ([]Finding, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var findings []Finding
+	lineNum := 0
+	s := bufio.NewScanner(f)
+
+	for s.Scan() {
+		lineNum++
+		line := s.Text()
+
+		// Skip comment lines
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+
+		matches := exportPattern.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		envVar := matches[1]
+		value := unquote(matches[2])
+
+		if !IsSecretEnvVar(envVar) {
+			continue
+		}
+
+		findings = append(findings, Finding{
+			FilePath: path,
+			Line:     lineNum,
+			EnvVar:   envVar,
+			Value:    value,
+		})
+	}
+
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return findings, nil
+}
+
+// ScanFiles scans multiple files and returns all findings.
+// Files that do not exist are silently skipped.
+func ScanFiles(paths []string) ([]Finding, error) {
+	var all []Finding
+	for _, path := range paths {
+		findings, err := ScanFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		all = append(all, findings...)
+	}
+	return all, nil
+}
+
+// IsSecretEnvVar returns true if the env var name matches a known registry entry
+// or ends with a secret-indicating suffix.
+func IsSecretEnvVar(envVar string) bool {
+	if registry.LookupByEnvVar(envVar) != nil {
+		return true
+	}
+	upper := strings.ToUpper(envVar)
+	for _, suffix := range secretSuffixes {
+		if strings.HasSuffix(upper, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// MaskValue masks a secret value for display, showing a recognized prefix
+// (or a short prefix) and the last 4 characters.
+func MaskValue(value string) string {
+	if len(value) <= 4 {
+		return "****"
+	}
+
+	prefix := ""
+	for _, p := range knownPrefixes {
+		if strings.HasPrefix(value, p) {
+			prefix = p
+			break
+		}
+	}
+
+	if prefix == "" {
+		if len(value) > 8 {
+			prefix = value[:4]
+		} else {
+			prefix = value[:2]
+		}
+	}
+
+	suffix := value[len(value)-4:]
+	return prefix + "..." + suffix
+}
+
+// unquote removes surrounding double or single quotes from a value.
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,306 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "test-*.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	return f.Name()
+}
+
+func TestScanFile_DoubleQuoted(t *testing.T) {
+	path := writeTempFile(t, `export OPENAI_API_KEY="sk-proj-abc123"`)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	f := findings[0]
+	if f.EnvVar != "OPENAI_API_KEY" {
+		t.Errorf("expected env var OPENAI_API_KEY, got %s", f.EnvVar)
+	}
+	if f.Value != "sk-proj-abc123" {
+		t.Errorf("expected value sk-proj-abc123, got %s", f.Value)
+	}
+	if f.Line != 1 {
+		t.Errorf("expected line 1, got %d", f.Line)
+	}
+}
+
+func TestScanFile_SingleQuoted(t *testing.T) {
+	path := writeTempFile(t, `export ANTHROPIC_API_KEY='sk-ant-secret456'`)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Value != "sk-ant-secret456" {
+		t.Errorf("expected value sk-ant-secret456, got %s", findings[0].Value)
+	}
+}
+
+func TestScanFile_Unquoted(t *testing.T) {
+	path := writeTempFile(t, `export GITHUB_TOKEN=ghp_abcdef1234567890`)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Value != "ghp_abcdef1234567890" {
+		t.Errorf("expected value ghp_abcdef1234567890, got %s", findings[0].Value)
+	}
+}
+
+func TestScanFile_SuffixPatterns(t *testing.T) {
+	content := `export MY_SERVICE_KEY="abc123secret"
+export AUTH_TOKEN="token_value_here"
+export DB_SECRET="supersecret1234"
+export AWS_CREDENTIALS="cred_value_here"
+`
+	path := writeTempFile(t, content)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 4 {
+		t.Fatalf("expected 4 findings, got %d", len(findings))
+	}
+
+	expected := []string{"MY_SERVICE_KEY", "AUTH_TOKEN", "DB_SECRET", "AWS_CREDENTIALS"}
+	for i, envVar := range expected {
+		if findings[i].EnvVar != envVar {
+			t.Errorf("finding %d: expected %s, got %s", i, envVar, findings[i].EnvVar)
+		}
+	}
+}
+
+func TestScanFile_IgnoresComments(t *testing.T) {
+	content := `# export OPENAI_API_KEY="sk-proj-abc123"
+  # export GITHUB_TOKEN="ghp_abcdef"
+export GROQ_API_KEY="gsk_real_key_here"
+`
+	path := writeTempFile(t, content)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].EnvVar != "GROQ_API_KEY" {
+		t.Errorf("expected GROQ_API_KEY, got %s", findings[0].EnvVar)
+	}
+}
+
+func TestScanFile_IgnoresNonSecret(t *testing.T) {
+	content := `export PATH="/usr/local/bin:$PATH"
+export EDITOR="vim"
+export LANG="en_US.UTF-8"
+export HOME="/Users/test"
+`
+	path := writeTempFile(t, content)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func TestScanFile_IgnoresNoValue(t *testing.T) {
+	content := `export OPENAI_API_KEY
+export PATH
+`
+	path := writeTempFile(t, content)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func TestScanFile_MultipleFindings(t *testing.T) {
+	content := `export EDITOR="vim"
+export OPENAI_API_KEY="sk-proj-abc123"
+export PATH="/usr/bin"
+export GITHUB_TOKEN="ghp_abcdef"
+`
+	path := writeTempFile(t, content)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+	if findings[0].Line != 2 {
+		t.Errorf("expected line 2, got %d", findings[0].Line)
+	}
+	if findings[1].Line != 4 {
+		t.Errorf("expected line 4, got %d", findings[1].Line)
+	}
+}
+
+func TestScanFile_LeadingWhitespace(t *testing.T) {
+	path := writeTempFile(t, `  export OPENAI_API_KEY="sk-proj-abc123"`)
+
+	findings, err := ScanFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+}
+
+func TestScanFile_FileNotFound(t *testing.T) {
+	_, err := ScanFile("/nonexistent/path/file.sh")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("expected not-exist error, got %v", err)
+	}
+}
+
+func TestScanFiles_MergesResults(t *testing.T) {
+	path1 := writeTempFile(t, `export OPENAI_API_KEY="sk-proj-abc"`)
+	path2 := writeTempFile(t, `export GITHUB_TOKEN="ghp_xyz"`)
+
+	findings, err := ScanFiles([]string{path1, path2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+}
+
+func TestScanFiles_SkipsMissing(t *testing.T) {
+	path := writeTempFile(t, `export OPENAI_API_KEY="sk-proj-abc"`)
+
+	findings, err := ScanFiles([]string{"/nonexistent", path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+}
+
+func TestIsSecretEnvVar_RegistryMatch(t *testing.T) {
+	cases := []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GITHUB_TOKEN", "GROQ_API_KEY"}
+	for _, envVar := range cases {
+		if !IsSecretEnvVar(envVar) {
+			t.Errorf("expected %s to be a secret env var", envVar)
+		}
+	}
+}
+
+func TestIsSecretEnvVar_SuffixMatch(t *testing.T) {
+	cases := []string{"MY_API_KEY", "AUTH_TOKEN", "DB_SECRET", "AWS_CREDENTIALS"}
+	for _, envVar := range cases {
+		if !IsSecretEnvVar(envVar) {
+			t.Errorf("expected %s to be a secret env var", envVar)
+		}
+	}
+}
+
+func TestIsSecretEnvVar_NonSecret(t *testing.T) {
+	cases := []string{"PATH", "HOME", "EDITOR", "LANG", "GOPATH", "NODE_ENV"}
+	for _, envVar := range cases {
+		if IsSecretEnvVar(envVar) {
+			t.Errorf("expected %s to NOT be a secret env var", envVar)
+		}
+	}
+}
+
+func TestMaskValue_KnownPrefix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"sk-proj-abcdef1234", "sk-proj-...1234"},
+		{"sk-ant-abcdef1234", "sk-ant-...1234"},
+		{"ghp_abcdef1234", "ghp_...1234"},
+		{"github_pat_abcdef1234", "github_pat_...1234"},
+		{"gsk_abcdef1234", "gsk_...1234"},
+		{"AIzaSyExample1234", "AIza...1234"},
+	}
+	for _, tt := range tests {
+		got := MaskValue(tt.input)
+		if got != tt.expected {
+			t.Errorf("MaskValue(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestMaskValue_UnknownPrefix(t *testing.T) {
+	// Long value (>8): first 4 + ... + last 4
+	got := MaskValue("abcdefghijklmnop")
+	if got != "abcd...mnop" {
+		t.Errorf("MaskValue long = %q, want %q", got, "abcd...mnop")
+	}
+
+	// Short value (5-8): first 2 + ... + last 4
+	got = MaskValue("abcdefgh")
+	if got != "ab...efgh" {
+		t.Errorf("MaskValue short = %q, want %q", got, "ab...efgh")
+	}
+}
+
+func TestMaskValue_VeryShort(t *testing.T) {
+	if got := MaskValue("abcd"); got != "****" {
+		t.Errorf("MaskValue(4 chars) = %q, want ****", got)
+	}
+	if got := MaskValue("ab"); got != "****" {
+		t.Errorf("MaskValue(2 chars) = %q, want ****", got)
+	}
+	if got := MaskValue(""); got != "****" {
+		t.Errorf("MaskValue(empty) = %q, want ****", got)
+	}
+}
+
+func TestDefaultTargets(t *testing.T) {
+	targets := DefaultTargets()
+	if len(targets) != 6 {
+		t.Fatalf("expected 6 targets, got %d", len(targets))
+	}
+
+	home, _ := os.UserHomeDir()
+	expectedFiles := []string{".zshrc", ".zshenv", ".zprofile", ".bashrc", ".bash_profile", ".profile"}
+	for i, f := range expectedFiles {
+		expected := filepath.Join(home, f)
+		if targets[i] != expected {
+			t.Errorf("target %d: expected %s, got %s", i, expected, targets[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add `internal/scanner` package — shared foundation for `sekret scan` and `sekret import` commands.

## Changes

- **New `internal/scanner` package**
  - `Finding` struct: file path, line number, env var name, raw value
  - `ScanFile()` / `ScanFiles()`: parse `export KEY=VALUE` statements (double-quoted, single-quoted, unquoted)
  - `IsSecretEnvVar()`: detect secrets by built-in registry match or suffix pattern (`_KEY`, `_TOKEN`, `_SECRET`, `_CREDENTIALS`)
  - `MaskValue()`: mask secret values for safe display (prefix + last 4 chars)
  - `DefaultTargets()`: default shell config file paths (`~/.zshrc`, `~/.bashrc`, etc.)
- **Migrate `maskKey` to `scanner.MaskValue`**
  - Remove `maskKey` from `cmd/list.go`, use `scanner.MaskValue` instead
  - Update `cmd/set.go` to use `scanner.MaskValue`
- **20 test cases** covering all scanner functions

## Related Issues

Closes #20

This package is the shared dependency for:
- #21 — `sekret scan` command
- #22 — `sekret import` command

## Checklist

- [x] Lint passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] Build succeeds (`make build`)