### PR TITLE
feat: implement sekret import command

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -27,11 +27,15 @@ func setup(t *testing.T) {
 	cmd.SetReadConfirm(func(_ string) (bool, error) {
 		return false, fmt.Errorf("readConfirm not configured for this test")
 	})
+	cmd.SetReadChoice(func(_ string) (string, error) {
+		return "", fmt.Errorf("readChoice not configured for this test")
+	})
 	t.Cleanup(func() {
 		config.SetPath("")
 		cmd.SetStore(keychain.NewOSStore())
 		cmd.SetReadPassword(nil)
 		cmd.SetReadConfirm(nil)
+		cmd.SetReadChoice(nil)
 		testStore = nil
 	})
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eazyhozy/sekret/internal/config"
+	"github.com/eazyhozy/sekret/internal/scanner"
+	"github.com/spf13/cobra"
+)
+
+var importFile string
+
+var importCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Import plaintext API keys from shell config files into sekret",
+	Long: `Parse export statements from shell config files and register them in sekret.
+
+By default, scans ~/.zshrc, ~/.zshenv, ~/.zprofile, ~/.bashrc,
+~/.bash_profile, and ~/.profile.
+
+Use --file to import from a specific file instead.`,
+	Args: cobra.NoArgs,
+	RunE: runImport,
+}
+
+func init() {
+	importCmd.Flags().StringVar(&importFile, "file", "", "import from a specific file")
+	rootCmd.AddCommand(importCmd)
+}
+
+// importResult tracks the outcome of a single finding during import.
+type importResult struct {
+	finding scanner.Finding
+	status  string // "imported", "skipped", "cancelled", "failed", "overwritten"
+	err     error  // non-nil only for "failed"
+}
+
+func runImport(_ *cobra.Command, _ []string) error {
+	stderr := rootCmd.ErrOrStderr()
+
+	paths, err := resolveImportTargets(importFile)
+	if err != nil {
+		return err
+	}
+
+	findings, err := scanner.ScanFiles(paths)
+	if err != nil {
+		return err
+	}
+
+	if len(findings) == 0 {
+		_, _ = fmt.Fprintln(stderr, "No exportable keys found.")
+		return nil
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(stderr, "\nFound %d exportable %s:\n\n",
+		len(findings), pluralize(len(findings), "key", "keys"))
+	_, _ = fmt.Fprintln(stderr, "Import each key? (y: import / s: skip / q: quit)")
+
+	results := make([]importResult, 0, len(findings))
+
+	for i, f := range findings {
+		result, err := processImportFinding(stderr, cfg, f, i, len(findings))
+		if err != nil {
+			return err
+		}
+
+		results = append(results, result)
+
+		if result.status == "cancelled" {
+			// Mark remaining findings as cancelled too
+			for _, remaining := range findings[i+1:] {
+				results = append(results, importResult{finding: remaining, status: "cancelled"})
+			}
+			break
+		}
+	}
+
+	printImportSummary(results)
+	return nil
+}
+
+// processImportFinding handles a single finding in the import loop.
+// Returns a fatal error only for config save failures.
+func processImportFinding(stderr interface{ Write([]byte) (int, error) }, cfg *config.Config, f scanner.Finding, index, total int) (importResult, error) {
+	displayPath := shortenHome(f.FilePath)
+
+	_, _ = fmt.Fprintf(stderr, "\n  [%d/%d] %s (%s)\n", index+1, total, f.EnvVar, displayMaskedValue(f.Value))
+	_, _ = fmt.Fprintf(stderr, "         %s:%d\n", displayPath, f.Line)
+
+	// Check if already registered in sekret
+	existing := cfg.FindKeyByEnvVar(f.EnvVar)
+	if existing != nil {
+		_, _ = fmt.Fprintf(stderr, "         Already registered in sekret.\n")
+		return handleOverwrite(stderr, cfg, f, existing)
+	}
+
+	return handleNewKey(stderr, cfg, f)
+}
+
+// handleOverwrite prompts for overwrite of an existing key.
+func handleOverwrite(stderr interface{ Write([]byte) (int, error) }, cfg *config.Config, f scanner.Finding, existing *config.KeyEntry) (importResult, error) {
+	choice, err := readChoice("         Overwrite? [y/N]: ")
+	if err != nil {
+		return importResult{}, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(choice)) {
+	case "y", "yes":
+		keychainKey := existing.KeychainKey()
+		if err := store.Set(keychainKey, f.Value); err != nil {
+			_, _ = fmt.Fprintf(stderr, "         Failed — %s\n", err)
+			return importResult{finding: f, status: "failed", err: err}, nil
+		}
+		_, _ = fmt.Fprintf(stderr, "         Overwritten %s\n", f.EnvVar)
+		return importResult{finding: f, status: "overwritten"}, nil
+	case "", "n", "no":
+		_, _ = fmt.Fprintf(stderr, "         Skipped\n")
+		return importResult{finding: f, status: "skipped"}, nil
+	default:
+		_, _ = fmt.Fprintf(stderr, "         Invalid choice. Use y or n.\n")
+		return handleOverwrite(stderr, cfg, f, existing)
+	}
+}
+
+// handleNewKey prompts for import of a new key.
+func handleNewKey(stderr interface{ Write([]byte) (int, error) }, cfg *config.Config, f scanner.Finding) (importResult, error) {
+	choice, err := readChoice("         Import? [Y/s/q]: ")
+	if err != nil {
+		return importResult{}, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(choice)) {
+	case "", "y", "yes":
+		return doImport(stderr, cfg, f)
+	case "s", "skip":
+		_, _ = fmt.Fprintf(stderr, "         Skipped\n")
+		return importResult{finding: f, status: "skipped"}, nil
+	case "q", "quit":
+		_, _ = fmt.Fprintf(stderr, "         Cancelled\n")
+		return importResult{finding: f, status: "cancelled"}, nil
+	default:
+		// Invalid input — re-prompt
+		_, _ = fmt.Fprintf(stderr, "         Invalid choice. Use y, s, or q.\n")
+		return handleNewKey(stderr, cfg, f)
+	}
+}
+
+// doImport saves a finding to keychain and config.
+func doImport(stderr interface{ Write([]byte) (int, error) }, cfg *config.Config, f scanner.Finding) (importResult, error) {
+	if err := store.Set(f.EnvVar, f.Value); err != nil {
+		_, _ = fmt.Fprintf(stderr, "         Failed — %s\n", err)
+		return importResult{finding: f, status: "failed", err: err}, nil
+	}
+
+	if err := cfg.AddKey("", f.EnvVar); err != nil {
+		return importResult{}, fmt.Errorf("failed to register key: %w", err)
+	}
+	if err := config.Save(cfg); err != nil {
+		return importResult{}, fmt.Errorf("failed to save config: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(stderr, "         Imported %s\n", f.EnvVar)
+	return importResult{finding: f, status: "imported"}, nil
+}
+
+// displayMaskedValue returns a display string for a value, handling empty values.
+func displayMaskedValue(value string) string {
+	if value == "" {
+		return "empty value"
+	}
+	return scanner.MaskValue(value)
+}
+
+// printImportSummary outputs the final result summary to stdout.
+func printImportSummary(results []importResult) {
+	imported := filterResults(results, "imported")
+	overwritten := filterResults(results, "overwritten")
+	skipped := filterResults(results, "skipped")
+	cancelled := filterResults(results, "cancelled")
+	failed := filterResults(results, "failed")
+
+	// Summary line
+	parts := []string{}
+	if n := len(imported) + len(overwritten); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d imported", n))
+	}
+	if len(skipped) > 0 {
+		parts = append(parts, fmt.Sprintf("%d skipped", len(skipped)))
+	}
+	if len(cancelled) > 0 {
+		parts = append(parts, fmt.Sprintf("%d cancelled", len(cancelled)))
+	}
+	if len(failed) > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed", len(failed)))
+	}
+
+	fmt.Printf("\nDone. %s.\n", strings.Join(parts, ", "))
+
+	// Detail sections
+	if len(imported) > 0 {
+		fmt.Println("\n  Imported:")
+		for _, r := range imported {
+			fmt.Printf("    %-12s %s\n", shortenHome(r.finding.FilePath)+":"+fmt.Sprint(r.finding.Line), r.finding.EnvVar)
+		}
+	}
+
+	if len(overwritten) > 0 {
+		fmt.Println("\n  Overwritten:")
+		for _, r := range overwritten {
+			fmt.Printf("    %-12s %s\n", shortenHome(r.finding.FilePath)+":"+fmt.Sprint(r.finding.Line), r.finding.EnvVar)
+		}
+	}
+
+	if len(skipped) > 0 {
+		fmt.Println("\n  Skipped:")
+		for _, r := range skipped {
+			fmt.Printf("    %-12s %s\n", shortenHome(r.finding.FilePath)+":"+fmt.Sprint(r.finding.Line), r.finding.EnvVar)
+		}
+	}
+
+	if len(cancelled) > 0 {
+		fmt.Println("\n  Cancelled:")
+		for _, r := range cancelled {
+			fmt.Printf("    %-12s %s\n", shortenHome(r.finding.FilePath)+":"+fmt.Sprint(r.finding.Line), r.finding.EnvVar)
+		}
+	}
+
+	if len(failed) > 0 {
+		fmt.Println("\n  Failed:")
+		for _, r := range failed {
+			fmt.Printf("    %-12s %s — %s\n",
+				shortenHome(r.finding.FilePath)+":"+fmt.Sprint(r.finding.Line),
+				r.finding.EnvVar, r.err)
+		}
+	}
+
+	// Advice to remove imported keys
+	if len(imported)+len(overwritten) > 0 {
+		fmt.Println("\nRemove the imported keys from your shell config (lines listed above).")
+	}
+}
+
+// filterResults returns results with the given status.
+func filterResults(results []importResult, status string) []importResult {
+	var filtered []importResult
+	for _, r := range results {
+		if r.status == status {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+// resolveImportTargets determines which files to scan for import.
+func resolveImportTargets(file string) ([]string, error) {
+	if file != "" {
+		return scanner.ResolvePath(file)
+	}
+	targets := scanner.DefaultTargets()
+	if targets == nil {
+		return nil, fmt.Errorf("could not determine home directory")
+	}
+	return targets, nil
+}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,0 +1,343 @@
+package cmd_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eazyhozy/sekret/cmd"
+	"github.com/eazyhozy/sekret/internal/config"
+	"github.com/eazyhozy/sekret/internal/keychain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// choiceSequence returns a readChoice mock that returns answers in order.
+func choiceSequence(answers ...string) func(string) (string, error) {
+	i := 0
+	return func(_ string) (string, error) {
+		if i >= len(answers) {
+			return "", fmt.Errorf("unexpected readChoice call #%d", i+1)
+		}
+		answer := answers[i]
+		i++
+		return answer, nil
+	}
+}
+
+// executeImport runs an import command and captures both stdout and stderr.
+func executeImport(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	var stderrBuf bytes.Buffer
+	cmd.RootCmd().SetErr(&stderrBuf)
+	t.Cleanup(func() { cmd.RootCmd().SetErr(nil) })
+
+	fullArgs := append([]string{"import"}, args...)
+	stdout = captureStdout(t, func() {
+		err = executeCmd(t, fullArgs...)
+	})
+	stderr = stderrBuf.String()
+	return
+}
+
+func writeImportFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.sh")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestImport_NoKeysFound(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export PATH="/usr/bin"
+export EDITOR="vim"
+`)
+
+	_, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "No exportable keys found")
+}
+
+func TestImport_ImportSingleKey(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-abcdef1234"`)
+	cmd.SetReadChoice(choiceSequence("y"))
+
+	stdout, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	// stderr: interactive messages
+	assert.Contains(t, stderr, "Found 1 exportable key")
+	assert.Contains(t, stderr, "[1/1] OPENAI_API_KEY")
+	assert.Contains(t, stderr, "Imported OPENAI_API_KEY")
+
+	// stdout: summary
+	assert.Contains(t, stdout, "1 imported")
+	assert.Contains(t, stdout, "Imported:")
+	assert.Contains(t, stdout, "OPENAI_API_KEY")
+	assert.Contains(t, stdout, "Remove the imported keys")
+
+	// Verify keychain and config
+	val, err := testStore.Get("OPENAI_API_KEY")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-proj-abcdef1234", val)
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.FindKeyByEnvVar("OPENAI_API_KEY"))
+}
+
+func TestImport_DefaultYes(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-abcdef1234"`)
+	cmd.SetReadChoice(choiceSequence("")) // empty = Enter = default yes
+
+	stdout, _, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "1 imported")
+
+	val, err := testStore.Get("OPENAI_API_KEY")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-proj-abcdef1234", val)
+}
+
+func TestImport_SkipKey(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-abcdef1234"`)
+	cmd.SetReadChoice(choiceSequence("s"))
+
+	stdout, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Skipped")
+	assert.Contains(t, stdout, "1 skipped")
+	assert.Contains(t, stdout, "Skipped:")
+	assert.NotContains(t, stdout, "Remove the imported keys")
+}
+
+func TestImport_QuitCancelsCurrentAndRemaining(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-abc"
+export GITHUB_TOKEN="ghp_xyz1234567890"
+export GROQ_API_KEY="gsk_test123456789"
+`)
+	cmd.SetReadChoice(choiceSequence("y", "q")) // import first, quit on second
+
+	stdout, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "[1/3] OPENAI_API_KEY")
+	assert.Contains(t, stderr, "Imported OPENAI_API_KEY")
+	assert.Contains(t, stderr, "[2/3] GITHUB_TOKEN")
+	assert.Contains(t, stderr, "Cancelled")
+
+	// stdout summary
+	assert.Contains(t, stdout, "1 imported")
+	assert.Contains(t, stdout, "2 cancelled")
+	assert.Contains(t, stdout, "Cancelled:")
+	assert.Contains(t, stdout, "GITHUB_TOKEN")
+	assert.Contains(t, stdout, "GROQ_API_KEY")
+
+	// First key was imported
+	_, err = testStore.Get("OPENAI_API_KEY")
+	require.NoError(t, err)
+
+	// Second and third keys were not imported
+	_, err = testStore.Get("GITHUB_TOKEN")
+	require.Error(t, err)
+	_, err = testStore.Get("GROQ_API_KEY")
+	require.Error(t, err)
+}
+
+func TestImport_AlreadyRegistered_OverwriteYes(t *testing.T) {
+	setup(t)
+	seedKey(t, "OPENAI_API_KEY", "sk-proj-old-value")
+
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-new-value"`)
+	cmd.SetReadChoice(choiceSequence("y"))
+
+	stdout, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Already registered in sekret")
+	assert.Contains(t, stderr, "Overwritten OPENAI_API_KEY")
+	assert.Contains(t, stdout, "1 imported")
+	assert.Contains(t, stdout, "Overwritten:")
+
+	// Verify value was updated
+	val, err := testStore.Get("OPENAI_API_KEY")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-proj-new-value", val)
+}
+
+func TestImport_AlreadyRegistered_OverwriteNo(t *testing.T) {
+	setup(t)
+	seedKey(t, "OPENAI_API_KEY", "sk-proj-old-value")
+
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-new-value"`)
+	cmd.SetReadChoice(choiceSequence("n"))
+
+	stdout, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Already registered in sekret")
+	assert.Contains(t, stderr, "Skipped")
+	assert.Contains(t, stdout, "1 skipped")
+
+	// Verify value was NOT updated
+	val, err := testStore.Get("OPENAI_API_KEY")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-proj-old-value", val)
+}
+
+func TestImport_AlreadyRegistered_DefaultNo(t *testing.T) {
+	setup(t)
+	seedKey(t, "OPENAI_API_KEY", "sk-proj-old-value")
+
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-new-value"`)
+	cmd.SetReadChoice(choiceSequence("")) // Enter = default N for overwrite
+
+	stdout, _, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "1 skipped")
+
+	val, err := testStore.Get("OPENAI_API_KEY")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-proj-old-value", val)
+}
+
+func TestImport_DuplicateKeyAcrossFiles(t *testing.T) {
+	setup(t)
+	dir := t.TempDir()
+	writeScanFile(t, dir, "a.sh", `export OPENAI_API_KEY="sk-proj-from-a"`)
+	writeScanFile(t, dir, "b.sh", `export OPENAI_API_KEY="sk-proj-from-b"`)
+
+	// Import first, then overwrite prompt for second (skip)
+	cmd.SetReadChoice(choiceSequence("y", "n"))
+
+	stdout, stderr, err := executeImport(t, "--file", dir)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "[1/2] OPENAI_API_KEY")
+	assert.Contains(t, stderr, "Imported OPENAI_API_KEY")
+	assert.Contains(t, stderr, "[2/2] OPENAI_API_KEY")
+	assert.Contains(t, stderr, "Already registered in sekret")
+	assert.Contains(t, stdout, "1 imported")
+	assert.Contains(t, stdout, "1 skipped")
+}
+
+func TestImport_KeychainSaveFailure(t *testing.T) {
+	setup(t)
+
+	// Use a store that fails on Set
+	failStore := &failingStore{MockStore: keychain.NewMockStore()}
+	cmd.SetStore(failStore)
+
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-abc"`)
+	cmd.SetReadChoice(choiceSequence("y"))
+
+	stdout, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Failed")
+	assert.Contains(t, stdout, "1 failed")
+	assert.Contains(t, stdout, "Failed:")
+	assert.NotContains(t, stdout, "Remove the imported keys")
+}
+
+func TestImport_EmptyValue(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export OPENAI_API_KEY=""`)
+	cmd.SetReadChoice(choiceSequence("y"))
+
+	_, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "[1/1] OPENAI_API_KEY (empty value)")
+}
+
+func TestImport_MixedActions(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-abc"
+export GITHUB_TOKEN="ghp_xyz1234567890"
+export GROQ_API_KEY="gsk_test123456789"
+`)
+	// import first, skip second, import third
+	cmd.SetReadChoice(choiceSequence("y", "s", "y"))
+
+	stdout, _, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "2 imported")
+	assert.Contains(t, stdout, "1 skipped")
+	assert.Contains(t, stdout, "Imported:")
+	assert.Contains(t, stdout, "OPENAI_API_KEY")
+	assert.Contains(t, stdout, "GROQ_API_KEY")
+	assert.Contains(t, stdout, "Skipped:")
+	assert.Contains(t, stdout, "GITHUB_TOKEN")
+	assert.Contains(t, stdout, "Remove the imported keys")
+}
+
+func TestImport_FileFlag(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-abc"`)
+	cmd.SetReadChoice(choiceSequence("y"))
+
+	stdout, _, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "1 imported")
+}
+
+func TestImport_InvalidChoice_Reprompts(t *testing.T) {
+	setup(t)
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-abc"`)
+	// First: invalid input, second: valid "y"
+	cmd.SetReadChoice(choiceSequence("x", "y"))
+
+	stdout, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Invalid choice. Use y, s, or q.")
+	assert.Contains(t, stdout, "1 imported")
+}
+
+func TestImport_InvalidOverwriteChoice_Reprompts(t *testing.T) {
+	setup(t)
+	seedKey(t, "OPENAI_API_KEY", "sk-proj-old-value")
+
+	path := writeImportFile(t, `export OPENAI_API_KEY="sk-proj-new-value"`)
+	// First: invalid input, second: valid "n"
+	cmd.SetReadChoice(choiceSequence("asdf", "n"))
+
+	stdout, stderr, err := executeImport(t, "--file", path)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Invalid choice. Use y or n.")
+	assert.Contains(t, stdout, "1 skipped")
+
+	// Value should NOT have been overwritten
+	val, err := testStore.Get("OPENAI_API_KEY")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-proj-old-value", val)
+}
+
+func TestImport_FileNotFound(t *testing.T) {
+	setup(t)
+	_, _, err := executeImport(t, "--file", "/nonexistent/path")
+	require.Error(t, err)
+}
+
+// failingStore wraps MockStore but always fails on Set.
+type failingStore struct {
+	*keychain.MockStore
+}
+
+func (s *failingStore) Set(_ string, _ string) error {
+	return fmt.Errorf("keychain unavailable")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,23 @@ func SetReadConfirm(fn func(string) (bool, error)) {
 	readConfirm = fn
 }
 
+// readChoice reads a single-line choice from the user.
+// Override with SetReadChoice() for testing.
+var readChoice = func(prompt string) (string, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	var answer string
+	if _, err := fmt.Fscanln(os.Stdin, &answer); err != nil {
+		// EOF or empty input (just Enter) — return empty string
+		return "", nil
+	}
+	return answer, nil
+}
+
+// SetReadChoice overrides the choice reader (for testing).
+func SetReadChoice(fn func(string) (string, error)) {
+	readChoice = fn
+}
+
 var rootCmd = &cobra.Command{
 	Use:     "sekret",
 	Version: version,

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -97,6 +97,8 @@ func runScan(_ *cobra.Command, _ []string) error {
 		fmt.Println(line)
 	}
 
+	fmt.Println("\nRun 'sekret import' to migrate these keys to the OS keychain.")
+
 	// Exit code 1 when keys are found
 	exitFunc(1)
 	return nil

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -22,7 +22,7 @@ type Finding struct {
 var secretSuffixes = []string{"_KEY", "_TOKEN", "_SECRET", "_CREDENTIALS"}
 
 // exportPattern matches `export KEY=VALUE` statements.
-var exportPattern = regexp.MustCompile(`^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(.+)$`)
+var exportPattern = regexp.MustCompile(`^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$`)
 
 // knownPrefixes are API key prefixes used for mask display (longest first).
 var knownPrefixes = []string{

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -105,6 +105,33 @@ export PATH
 	assert.Empty(t, findings)
 }
 
+func TestScanFile_EmptyQuotedValue(t *testing.T) {
+	content := `export OPENAI_API_KEY=""
+export GITHUB_TOKEN=''
+`
+	path := writeTempFile(t, content)
+
+	findings, err := ScanFile(path)
+	require.NoError(t, err)
+	require.Len(t, findings, 2)
+	assert.Equal(t, "OPENAI_API_KEY", findings[0].EnvVar)
+	assert.Equal(t, "", findings[0].Value)
+	assert.Equal(t, "GITHUB_TOKEN", findings[1].EnvVar)
+	assert.Equal(t, "", findings[1].Value)
+}
+
+func TestScanFile_EmptyUnquotedValue(t *testing.T) {
+	content := `export OPENAI_API_KEY=
+`
+	path := writeTempFile(t, content)
+
+	findings, err := ScanFile(path)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "OPENAI_API_KEY", findings[0].EnvVar)
+	assert.Equal(t, "", findings[0].Value)
+}
+
 func TestScanFile_MultipleFindings(t *testing.T) {
 	content := `export EDITOR="vim"
 export OPENAI_API_KEY="sk-proj-abc123"


### PR DESCRIPTION
## Summary

Add `sekret import` command that interactively migrates plaintext API keys from shell config files into the OS keychain.

## Changes

- Add `sekret import` with `--file` flag and interactive `[Y/s/q]` loop
- Handle duplicate keys (already registered in sekret) with `Overwrite? [y/N]` prompt
- Re-prompt on invalid input for both import and overwrite prompts
- Add `readChoice` DI function in `cmd/root.go` for testable user input
- Update scanner regex `(.+)` → `(.*)` to detect empty values (`export KEY=`, `export KEY=""`)
- Add `Run 'sekret import'` suggestion to `sekret scan` output
- 16 test cases covering: basic import, skip, quit (current+remaining cancelled), overwrite yes/no/default, duplicate across files, keychain failure, empty value, mixed actions, invalid input re-prompt, file flag

## Usage Example

```
$ sekret import

Found 3 exportable keys:

Import each key? (y: import / s: skip / q: quit)

  [1/3] OPENAI_API_KEY (sk-proj-...1234)
         ~/.zshrc:12
         Import? [Y/s/q]: y
         Imported OPENAI_API_KEY

  [2/3] KAP_API_KEY (kap_...V0dQ)
         ~/.zshrc:168
         Import? [Y/s/q]: y
         Imported KAP_API_KEY

  [3/3] SLACK_WEBHOOK_SECRET (sl-wh...xYz9)
         ~/.zshrc:200
         Import? [Y/s/q]: s
         Skipped

Done. 2 imported, 1 skipped.

  Imported:
    ~/.zshrc:12  OPENAI_API_KEY
    ~/.zshrc:168 KAP_API_KEY

  Skipped:
    ~/.zshrc:200 SLACK_WEBHOOK_SECRET

Remove the imported keys from your shell config (lines listed above).
```

When a key is already registered in sekret:

```
  [1/1] OPENAI_API_KEY (sk-proj-...5678)
         ~/.zshrc:12
         Already registered in sekret.
         Overwrite? [y/N]: n
         Skipped
```

## Related Issues

Closes #22

## Checklist

- [x] Lint passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] Build succeeds (`make build`)